### PR TITLE
Add -nodeh option to EditGame and support for .deh files

### DIFF
--- a/base/cfg.go
+++ b/base/cfg.go
@@ -78,7 +78,7 @@ func init() {
 func defaultConfig() Cfg {
 	config := Cfg{
 		WadDir:                filepath.Join(helper.Home(), "/DOOM"),
-		ModExtensions:         ".wad.pk3.ipk3.pke",
+		ModExtensions:         ".wad.pk3.ipk3.pke.deh",
 		Ports:                 []string{"gzdoom", "zandronum", "lzdoom"},
 		IWADs:                 []string{"doom2.wad", "doom.wad", "plutonia.wad", "tnt.wad", "heretic.wad", "boa.ipk3"},
 		GameListRelativeWidth: 40,
@@ -185,6 +185,10 @@ func updateConfig() {
 		// new known mod extension
 		if !strings.Contains(instance.ModExtensions, ".pke") {
 			instance.ModExtensions = instance.ModExtensions + ".pke"
+		}
+
+		if !strings.Contains(instance.ModExtensions, ".deh") {
+			instance.ModExtensions = instance.ModExtensions + ".deh"
 		}
 		// additional known iwads
 		instance.IWADs = append(instance.IWADs, "boa.ipk3", "plutonia.wad", "tnt.wad", "heretic.wad")

--- a/games/game.go
+++ b/games/game.go
@@ -66,6 +66,16 @@ func NewGame(name, sourceport, sharedConfig, iwad string) Game {
 	return game
 }
 
+func isDehFile(file string) bool {
+	s := file[len(file)-3:]
+
+	if (s == "deh" || s == "DEH") {
+		return true
+	}
+
+	return false
+}
+
 // Run executes given configuration and launches the mod
 // Just a wrapper for game.run
 func (g *Game) Run() (err error) {
@@ -188,14 +198,32 @@ func (g *Game) getLaunchParams(rcfg runOptionSet) []string {
 		params = append(params, "-iwad", g.Iwad) // -iwad seems to be universal across zdoom, boom and chocolate doom
 	}
 
-	// mods
+	modsWads := []string{}
+	modsDeh  := []string{}
+
 	if len(g.Mods) > 0 {
+		for _, file := range g.Mods {
+			if isDehFile(file) {
+				modsDeh = append(modsDeh, os.Getenv("DOOMWADDIR") + "/" + file)
+			} else {
+				modsWads = append(modsWads, file)
+			}
+		}
+	}
+
+	// mods
+	if len(modsWads) > 0 {
 		params = append(params, "-file") // -file seems to be universal across zdoom, boom and chocolate doom
-		params = append(params, g.Mods...)
+		params = append(params, modsWads...)
 	}
 
 	if g.NoDeh {
 		params = append(params, "-nodeh")
+	}
+
+	if len(modsDeh) > 0 {
+		params = append(params, "-deh")
+		params = append(params, modsDeh...)
 	}
 
 	// custom game save directory

--- a/games/game.go
+++ b/games/game.go
@@ -66,9 +66,12 @@ func NewGame(name, sourceport, sharedConfig, iwad string) Game {
 	return game
 }
 
+// Checks if FILE is a DeHacked file
+// by comparing its last three letters to "deh" or "DEH"
 func isDehFile(file string) bool {
 	s := file[len(file)-3:]
 
+	// Lowercase or uppercase are both common
 	if (s == "deh" || s == "DEH") {
 		return true
 	}
@@ -198,12 +201,16 @@ func (g *Game) getLaunchParams(rcfg runOptionSet) []string {
 		params = append(params, "-iwad", g.Iwad) // -iwad seems to be universal across zdoom, boom and chocolate doom
 	}
 
+	// some mapsets need both .wad files (wad, pk3, pke, etc.) and DeHacked files (.deh) to work on some ports
+	// but the former needs a -file parameter, while the latter needs a -deh parameter
+	// so we split g.Mods in two by using the isDehFile() function
 	modsWads := []string{}
 	modsDeh  := []string{}
 
 	if len(g.Mods) > 0 {
 		for _, file := range g.Mods {
 			if isDehFile(file) {
+				// some ports (e.g. Woof!) don't auto check for .deh files on DOOMWADDIR
 				modsDeh = append(modsDeh, os.Getenv("DOOMWADDIR") + "/" + file)
 			} else {
 				modsWads = append(modsWads, file)
@@ -211,16 +218,18 @@ func (g *Game) getLaunchParams(rcfg runOptionSet) []string {
 		}
 	}
 
-	// mods
+	// mods 
 	if len(modsWads) > 0 {
 		params = append(params, "-file") // -file seems to be universal across zdoom, boom and chocolate doom
 		params = append(params, modsWads...)
 	}
 
+	// some mods need this
 	if g.NoDeh {
 		params = append(params, "-nodeh")
 	}
 
+	// DeHacked files
 	if len(modsDeh) > 0 {
 		params = append(params, "-deh")
 		params = append(params, modsDeh...)

--- a/games/game.go
+++ b/games/game.go
@@ -35,6 +35,7 @@ type Game struct {
 	AddEdit          time.Time      `json:"added"`
 	Link             string         `json:"link"`
 	PersonalPortCfg  bool           `json:"own_source_port_cfg"`
+	NoDeh            bool           `json:"no_deh"`
 	SharedConfig     string         `json:"shared_config"`
 	Stats            []st.MapStats
 	StatsTotal       st.MapStats
@@ -191,6 +192,10 @@ func (g *Game) getLaunchParams(rcfg runOptionSet) []string {
 	if len(g.Mods) > 0 {
 		params = append(params, "-file") // -file seems to be universal across zdoom, boom and chocolate doom
 		params = append(params, g.Mods...)
+	}
+
+	if g.NoDeh {
+		params = append(params, "-nodeh")
 	}
 
 	// custom game save directory

--- a/tui/addEditGame.go
+++ b/tui/addEditGame.go
@@ -51,6 +51,7 @@ func makeAddEditGame(g *games.Game) *tview.Flex {
 	// create basic form items
 	inputName := tview.NewInputField().SetText(g.Name).SetLabel(dict.aeName).SetLabelColor(tview.Styles.SecondaryTextColor)
 	inputOwnCfg := tview.NewCheckbox().SetChecked(g.PersonalPortCfg).SetLabel(dict.aeOwnCfg).SetLabelColor(tview.Styles.SecondaryTextColor)
+	inputNoDeh := tview.NewCheckbox().SetLabel(dict.aeNoDeh).SetLabelColor(tview.Styles.SecondaryTextColor)
 	inputSharedCfg := tview.NewInputField().SetText(g.SharedConfig).SetLabel(fmt.Sprintf(dict.aeSharedCfgT, expectedExtension)).SetLabelColor(tview.Styles.SecondaryTextColor)
 	if g.PersonalPortCfg {
 		inputSharedCfg.SetLabel(warnColor + fmt.Sprintf(dict.aeSharedCfgT, expectedExtension))
@@ -129,6 +130,7 @@ func makeAddEditGame(g *games.Game) *tview.Flex {
 	ae.AddFormItem(inputSourcePort)
 	ae.AddFormItem(inputIwad)
 	ae.AddFormItem(inputOwnCfg)
+	ae.AddFormItem(inputNoDeh)
 	ae.AddFormItem(inputSharedCfg)
 	ae.AddFormItem(inputURL)
 	ae.AddFormItem(inputEnvVars)

--- a/tui/addEditGame.go
+++ b/tui/addEditGame.go
@@ -51,7 +51,8 @@ func makeAddEditGame(g *games.Game) *tview.Flex {
 	// create basic form items
 	inputName := tview.NewInputField().SetText(g.Name).SetLabel(dict.aeName).SetLabelColor(tview.Styles.SecondaryTextColor)
 	inputOwnCfg := tview.NewCheckbox().SetChecked(g.PersonalPortCfg).SetLabel(dict.aeOwnCfg).SetLabelColor(tview.Styles.SecondaryTextColor)
-	inputNoDeh := tview.NewCheckbox().SetLabel(dict.aeNoDeh).SetLabelColor(tview.Styles.SecondaryTextColor)
+	// TODO: Add SetChecked()
+	inputNoDeh := tview.NewCheckbox().SetChecked(g.NoDeh).SetLabel(dict.aeNoDeh).SetLabelColor(tview.Styles.SecondaryTextColor)
 	inputSharedCfg := tview.NewInputField().SetText(g.SharedConfig).SetLabel(fmt.Sprintf(dict.aeSharedCfgT, expectedExtension)).SetLabelColor(tview.Styles.SecondaryTextColor)
 	if g.PersonalPortCfg {
 		inputSharedCfg.SetLabel(warnColor + fmt.Sprintf(dict.aeSharedCfgT, expectedExtension))
@@ -141,9 +142,11 @@ func makeAddEditGame(g *games.Game) *tview.Flex {
 		_, g.Port = inputSourcePort.GetCurrentOption()
 		_, g.Iwad = inputIwad.GetCurrentOption()
 		g.PersonalPortCfg = inputOwnCfg.IsChecked()
+		g.NoDeh = inputNoDeh.IsChecked()
 		g.SharedConfig = inputSharedCfg.GetText()
 		g.Environment = splitParams(inputEnvVars.GetText())
 		g.CustomParameters = splitParams(inputCustomParams.GetText())
+		
 		g.Link = inputURL.GetText()
 
 		if gWasNil {

--- a/tui/commandPreview.go
+++ b/tui/commandPreview.go
@@ -30,6 +30,8 @@ func stylizeCommandList(params []string) string {
 	keywords := map[string]bool{
 		"-iwad":          true,
 		"-file":          true,
+		"-nodeh":         true,
+		"-deh":           true,
 		"-savedir":       true,
 		"-save":          true,
 		"-config":        true,

--- a/tui/dict.go
+++ b/tui/dict.go
@@ -12,6 +12,7 @@ type dictionary struct {
 	aeSourcePort string
 	aeIWAD       string
 	aeOwnCfg     string
+	aeNoDeh      string
 	aeSharedCfgT string
 	aeLink       string
 
@@ -98,6 +99,7 @@ func defaultDict() dictionary {
 		aeSourcePort: "Source Port",
 		aeIWAD:       "IWAD",
 		aeOwnCfg:     "Use Own Config",
+		aeNoDeh:      "nodeh",
 		aeSharedCfgT: "Use Shared Config [%v]",
 		aeLink:       "Mod URL",
 


### PR DESCRIPTION
Hi, I added support for DeHacked files, as some mods need it on some ports (like D4V on Crispy DOOM). Here's a detailed list of what I did:

1. Added a "NoDeh" bool member to Game struct (game.go)
2. -nodeh checkbox now persists
3. If -nodeh is checked, "-nodeh" is added to the launch parameters after "-file" arguments
4. The "-nodeh" and "-deh" strings are now colored
5. .deh is now a valid extension for files (had to regenerate twad.json on ~/.config/twad)
6. isDehFile(string) is a new function to check if a file is of a .deh or .DEH extension
7. Mod files are now separated into two arrays: NonDehFiles (where .wad, .pke, .pk3, and such files go) and DehFiles (where all .deh files go)
8. Now mods are appended to the launch parameters as follows:
   1) If g.Mods is not empty, separate g.Mods into modsWads and modsDeh (see 7)
   2) If modsWads is not empty, append "-file" and all modsWads elements to the launch parameters
   3) If modsDeh is not empty, append "-deh" and all modsDeh elements to the launch parameters.
9. The order is: -file *modsWads...* -nodeh (optional) -deh *modsDeh...*

Cheers and thanks for TWAD!